### PR TITLE
Update shebang to improve portability

### DIFF
--- a/apps/notion/notion.desktop
+++ b/apps/notion/notion.desktop
@@ -4,7 +4,7 @@ Type=Application
 Name=Notion
 GenericName=Notes
 Comment=A new tool that blends your everyday work apps into one.
-Exec=/usr/bin/google-chrome --app=https://notion.so/
+Exec=$(which google-chrome-stable) --app=https://notion.so/
 Icon=notion
 Terminal=false
 Categories=Utility;

--- a/apps/todomate/todomate.desktop
+++ b/apps/todomate/todomate.desktop
@@ -4,7 +4,7 @@ Type=Application
 Name=Todo Mate
 GenericName=Todo Manager
 Comment=Make your day perfect with the easy-to-use and pretty todo mate app.
-Exec=/usr/bin/google-chrome --app=https://todomate.net
+Exec=$(which google-chrome-stable) --app=https://todomate.net
 Icon=todomate
 Terminal=false
 Categories=Utility;

--- a/apps/youtube-music/youtube-music.desktop
+++ b/apps/youtube-music/youtube-music.desktop
@@ -4,7 +4,7 @@ Type=Application
 Name=Youtube Music
 GenericName=Todo Manager
 Comment=A new music service with official albums, singles, videos, remixes, live performances and more for Android, iOS and desktop. It's all here.
-Exec=/usr/bin/google-chrome --app=https://music.youtube.com/
+Exec=$(which google-chrome-stable) --app=https://music.youtube.com/
 Icon=youtube-music
 Terminal=false
 Categories=AudioVideo;Player;

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/usr/bin/env bash
 
 valid_choices="notion todomate youtube-music"
 

--- a/website/app/components/AppUnchainer.vue
+++ b/website/app/components/AppUnchainer.vue
@@ -35,7 +35,7 @@ const browsers: TBrowser[] = [{
   value: "chrome",
   label: "Chrome",
   defaultExecutablePath: {
-    linux: "/usr/bin/google-chrome-stable",
+    linux: "$(which google-chrome-stable)",
     macos: "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
     windows: "C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe",
   },
@@ -44,7 +44,7 @@ const browsers: TBrowser[] = [{
   value: "brave",
   label: "Brave",
   defaultExecutablePath: {
-    linux: "/usr/bin/brave",
+    linux: "$(which brave)",
     macos: "/Applications/Brave Browser.app/Contents/MacOS/Brave Browser",
     windows: "C:\\Program Files\\BraveSoftware\\Brave-Browser\\Application\\brave.exe",
   },
@@ -53,7 +53,7 @@ const browsers: TBrowser[] = [{
   value: "edge",
   label: "Edge",
   defaultExecutablePath: {
-    linux: "/usr/bin/microsoft-edge",
+    linux: "$(which microsoft-edge)",
     macos: "/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge",
     windows: "C:\\Program Files (x86)\\Microsoft\\Edge\\Application\\msedge.exe",
   },
@@ -63,7 +63,7 @@ const browsers: TBrowser[] = [{
   value: "firefox",
   label: "Firefox (to be implemented)",
   defaultExecutablePath: {
-    linux: "/usr/bin/firefox",
+    linux: "$(which firefox)",
     macos: "/Applications/Firefox.app/Contents/MacOS/firefox",
     windows: "C:\\Program Files\\Mozilla Firefox\\firefox.exe",
   },


### PR DESCRIPTION
Changed the shebang from /usr/bin/bash to /usr/bin/env bash.

Should fix the error in nixos.
Also automated PATH detection for browsers using which. Linux only.
