### PR TITLE
Fix issue with URL bar not hidden on Firefox

### DIFF
--- a/server/templates/files/userChrome.css
+++ b/server/templates/files/userChrome.css
@@ -2,6 +2,10 @@ TabsToolbar {
   visibility: collapse;
 }
 
+#nav-bar {
+  visibility: collapse;
+}
+
 :root:not([customizing]) #navigator-toolbox {
   max-height: 1px;
   min-height: calc(0px);


### PR DESCRIPTION
## Overview
A recent update to Firefox has broken the FTWA config which hides the URL bar. Adding an additional CSS rule to collapse the visibility of `#nav-bar` appears to fix this.

This fixes #17 

## Screenshots
_Using https://scryfall.com as an example_

### Before
![URLBarVisibleFTWA](https://github.com/user-attachments/assets/498097fb-b7a8-40f0-94bf-165c26b8c1bc)

### After
![URLBarHiddenFTWA](https://github.com/user-attachments/assets/3ba188cc-de6f-46ca-8fda-f37489b7c759)
