### PR TITLE
fix(why): drop inaccurate Slack vs GTA V comparison

### DIFF
--- a/app/pages/why.vue
+++ b/app/pages/why.vue
@@ -521,7 +521,7 @@ const pwaStack = [
                   150–300 MB
                 </td>
                 <td class="py-4 pr-4">
-                  ~ 1 MB cache
+                  5–50 MB cache
                 </td>
                 <td class="py-4 pr-4 font-bold text-primary-600 dark:text-primary-400">
                   ≈ 1.5 KB

--- a/app/pages/why.vue
+++ b/app/pages/why.vue
@@ -521,7 +521,7 @@ const pwaStack = [
                   150–300 MB
                 </td>
                 <td class="py-4 pr-4">
-                  5–50 MB cache
+                  ~ 1 MB cache
                 </td>
                 <td class="py-4 pr-4 font-bold text-primary-600 dark:text-primary-400">
                   ≈ 1.5 KB

--- a/app/pages/why.vue
+++ b/app/pages/why.vue
@@ -271,7 +271,7 @@ const pwaStack = [
               </span>
             </div>
             <p class="serif mt-4 max-w-xl text-2xl italic leading-snug text-stone-300">
-              of disk, per app, before you've sent a single message. Slack alone is reportedly heavier than the install size of GTA V.
+              of disk, per app, before you've sent a single message. Every Electron app ships its own copy of Chromium — install ten and you've cloned a browser ten times over.
             </p>
           </div>
           <div


### PR DESCRIPTION
GTA V's install size (~95 GB) dwarfs Slack's (~400 MB) by orders of magnitude, so the original line was factually wrong. Replace with an accurate Chromium-duplication line that keeps the rhetorical punch.

https://claude.ai/code/session_01MhqJTXR9u62zHyyjryk9tV